### PR TITLE
Allow logging from other modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,20 @@
 
 ## Development setup
 
+Using `docker-compose` (*recommended*):
+```shell
+[~/summarizer-server] $ docker-compose up -d --build api
+```
+
+To use a different port or to run with debug logging:
+```shell
+[~/summarizer-server] $ PORT=4000 DEBUG=true docker-compose up -d --build api
+```
+
 Using `docker`:
 ```shell
 [~/summarizer-server] $ docker build -t summarizer-server ./docker
 [~/summarizer-server] $ docker run --rm -p 5000:5000 summarizer-server
-```
-
-Using `docker-compose`:
-```shell
-[~/summarizer-server] $ docker-compose up -d --build api
 ```
 
 Note, if a mounted volume is needed then uncomment the commented out portions of the `docker-compose.override.yml` file. *Changes to this file should NOT be pushed, which is why it's in the `.gitignore`.*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,8 @@ services:
       context: ./
       dockerfile: ./docker/Dockerfile
     ports:
-      - "5000:5000"
+      - "${PORT:-5000}:${PORT:-5000}"
     network_mode: "bridge"
+    environment: # forward these from shell to the container at runtime
+      - DEBUG
+      - PORT

--- a/summarizer_server/server.py
+++ b/summarizer_server/server.py
@@ -47,7 +47,9 @@ def configure_logger(debug):
 
     # Configure logger and remove default flask logging
     handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    )
     handler.setFormatter(formatter)
     handler.setLevel(log_level)
     logging.getLogger().addHandler(handler)

--- a/summarizer_server/server.py
+++ b/summarizer_server/server.py
@@ -10,11 +10,7 @@ log = logging.getLogger("summarizer_server")
 app = Flask(__name__)
 textrank = TextRank()
 
-""" Change this to True to debug. I tried to read from env vars like
-`DEBUG=true docker-compose up` but that wasn't working.
-"""
-debug = False
-#  debug = True
+debug = os.environ.get("DEBUG", "false").lower() == "true"
 
 
 @app.before_first_request

--- a/summarizer_server/text_rank.py
+++ b/summarizer_server/text_rank.py
@@ -1,3 +1,4 @@
+import logging
 import pickle
 import os
 import re
@@ -10,6 +11,8 @@ from nltk import tokenize
 from nltk import corpus
 from sklearn.metrics.pairwise import cosine_similarity
 from image_setup import WORD_EMBEDDINGS_FILE
+
+log = logging.getLogger("summarizer_server")
 
 
 class TextRank:
@@ -80,4 +83,5 @@ class TextRank:
         for i in range(int(len(clean_sentences) * percent_sentences / 100)):
             top_sentences.append(sentences[ranked_sentences[i][1]])
 
+        log.debug(f"Returning {len(top_sentences)} sentences")
         return top_sentences


### PR DESCRIPTION
* now we can easily do logging from `text_rank.py` which should make development and debugging easier
* also forwards environment variables from the shell from where `docker-compose up` is run, so that we can do things like `DEBUG=true docker-compose up`