### PR TITLE
Add production webserver

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,7 +1,44 @@
-# this file is for devs only
 version: "3"
 
-# services:
-#   api:
-#     volumes:
-#       - .:/server
+services:
+  api:
+    image: summarizer_server
+    container_name: summarizer_server
+    build:
+      context: ./
+      dockerfile: ./docker/Dockerfile
+    ports:
+      - "${PORT:-5000}:${PORT:-5000}"
+    network_mode: "bridge"
+    environment: # forward these from shell to the container at runtime
+      - DEBUG
+      - PORT
+      - JOBLIB_MULTIPROCESSING=0
+    command: [
+      "uwsgi",
+      "--thunder-lock",
+      # "--uid", "uwsgi",
+      # "--protocol", "uwsgi",
+      "--socket", ":5000",
+      "--chmod-socket",
+      "--chdir", "/server/summarizer_server",
+      "--module", "server",
+      "--master",
+      # "--wsgi-file", "summarizer_server/server.py",
+      "--callable", "app",
+      # "--plugin", "python37",
+      # "--ini", "/server/summarizer_server/uwsgi.ini",
+      "--enable-threads",
+      "--processes", "4",
+    ]
+  nginx:
+    image: nginx:1.17
+    ports:
+      - "80:80"
+    volumes:
+      - "./summarizer_server/nginx.conf:/etc/nginx/conf.d/default.conf:ro"
+    network_mode: "bridge"
+    links:
+      - api
+    depends_on:
+      - api

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -28,15 +28,18 @@ services:
       "--callable", "app",
       # "--plugin", "python37",
       # "--ini", "/server/summarizer_server/uwsgi.ini",
-      "--enable-threads",
-      "--processes", "4",
+      # "--enable-threads",
+      "--processes", "2",
     ]
   nginx:
     image: nginx:1.17
     ports:
       - "80:80"
+      - "443:443"
     volumes:
       - "./summarizer_server/nginx.conf:/etc/nginx/conf.d/default.conf:ro"
+      - "./summarizer_server/nginx.key:/etc/nginx/ssl/nginx.key:ro"
+      - "./summarizer_server/nginx.crt:/etc/nginx/ssl/nginx.crt:ro"
     network_mode: "bridge"
     links:
       - api

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,33 +2,24 @@ version: "3"
 
 services:
   api:
-    image: summarizer_server
+    image: gcr.io/alpine-gasket-242504/summarizer-server:uwsgi
     container_name: summarizer_server
-    build:
-      context: ./
-      dockerfile: ./docker/Dockerfile
     ports:
       - "${PORT:-5000}:${PORT:-5000}"
     network_mode: "bridge"
     environment: # forward these from shell to the container at runtime
       - DEBUG
       - PORT
-      - JOBLIB_MULTIPROCESSING=0
+      - JOBLIB_MULTIPROCESSING=0 # this removes a uwsgi warning
     command: [
       "uwsgi",
       "--thunder-lock",
-      # "--uid", "uwsgi",
-      # "--protocol", "uwsgi",
       "--socket", ":5000",
       "--chmod-socket",
       "--chdir", "/server/summarizer_server",
       "--module", "server",
       "--master",
-      # "--wsgi-file", "summarizer_server/server.py",
       "--callable", "app",
-      # "--plugin", "python37",
-      # "--ini", "/server/summarizer_server/uwsgi.ini",
-      # "--enable-threads",
       "--processes", "2",
     ]
   nginx:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update -y && \
     apt-get install -y software-properties-common wget unzip && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y && \
-    apt-get install -y python3.7 python3-pip
+    apt-get install -y python3.7 python3.7-dev python3-pip
 
 RUN mkdir /data
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ nltk
 numpy
 pandas
 sklearn
+uwsgi

--- a/summarizer_server/nginx.conf
+++ b/summarizer_server/nginx.conf
@@ -1,0 +1,15 @@
+upstream flask {
+    server api:5000;
+}
+
+server {
+    listen 80;
+    # location / {
+    #     try_files $uri @wsgi;
+    # }
+    server_name localhost;
+    location / {
+        include uwsgi_params;
+        uwsgi_pass flask;
+    }
+}

--- a/summarizer_server/nginx.conf
+++ b/summarizer_server/nginx.conf
@@ -4,10 +4,9 @@ upstream flask {
 
 server {
     listen 80;
-    # location / {
-    #     try_files $uri @wsgi;
-    # }
-    server_name localhost;
+    listen 443 ssl;
+    ssl_certificate     /etc/nginx/ssl/nginx.crt;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
     location / {
         include uwsgi_params;
         uwsgi_pass flask;


### PR DESCRIPTION
This stops using the flask development webserver (1 request at a time) on prod deployments.

This starts uwsgi + flask in one container, and nginx in another. nginx forwards requests to the uwsgi container.

Right now nginx supports http and https via self-signed certs. I'm thinking of adding the certs encrypted to this repo via ansible vault or something in a later PR.