### PR TITLE
Merging newspaper's nlp summarization with text rank

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ build:
 	docker-compose build
 
 run: build
-	docker-compose up
+	DEBUG=true docker-compose up
 
 install:
 	pip3.7 install -r requirements.txt

--- a/summarizer_server/repl.py
+++ b/summarizer_server/repl.py
@@ -21,6 +21,11 @@ output_type = OutputType.SUMMARY
 signal.signal(signal.SIGINT, sigint_handler)
 
 
+def print_summary(summary):
+    for sentence in summary:
+        print(sentence)
+
+
 def handle_commands(command, response):
     global output_type
     if command == ":exit" or command == ":quit" or command == ":q":
@@ -73,7 +78,7 @@ if __name__ == "__main__":
             response = requests.post(
                 "http://localhost:5000/api/summarize", json={"html": html}
             )
-            print(response.content)
+            print_summary(json.loads(response.content))
         else:
             rank = text_rank.TextRank()
-            print(rank.process_html(html))
+            print(rank.process_html(html).text)

--- a/summarizer_server/text_rank.py
+++ b/summarizer_server/text_rank.py
@@ -124,9 +124,5 @@ class TextRank:
         sentence_indices = list(
             map(lambda x: x[0], totalled_scores.most_common(num_sentences))
         )
-        log.info(sentence_indices)
-        log.info(sum(textrank_scores.values()))
-        log.info(sum(nlp_scores.values()))
 
-        log.info("Returning newspaper summary \n" + article.summary)
         return list(map(lambda x: sentences[x], sentence_indices))

--- a/summarizer_server/text_rank.py
+++ b/summarizer_server/text_rank.py
@@ -100,9 +100,6 @@ class TextRank:
         # get newspaper's nlp scores
         # https://github.com/codelucas/newspaper/blob/master/newspaper/article.py#L372
         nlp.load_stopwords(article.config.get_language())
-        text_keywords = list(nlp.keywords(article.text).keys())
-        title_keywords = list(nlp.keywords(article.title).keys())
-        keywords = list(set(title_keywords + text_keywords))
 
         # call to: nlp.summarize(title=article.title, text=article.text, max_sents=max_sents)
         # https://github.com/codelucas/newspaper/blob/master/newspaper/nlp.py#L40


### PR DESCRIPTION
After some AB testing with newspaper's `Article.summary` and our text rank, we found out that there are some instances where newspaper's summaries are better and some cases where text rank is better. Better in this case just means more coherent.

An observation that was made was that the summarization algorithms often returned very different sentences and would make an amazing summary if they were combined. And thus this PR is proposed.

Changes to the algorithm:
- We extract the scores produced from the `newspaper3k` library, these scores are determined from frequency of keywords in a sentence, a sentence's similarity to the title, length of the sentence and position of the sentence.
- We normalize both scores produced by TextRank and newspaper.nlp
- We merge the scores together (summing them for each sentence) and produce the top n sentences with the highest scores.