### PR TITLE
Add rate limiting on nginx

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   api:
-    image: gcr.io/alpine-gasket-242504/summarizer-server:uwsgi
+    image: gcr.io/alpine-gasket-242504/summarizer-server:latest
     container_name: summarizer_server
     ports:
       - "${PORT:-5000}:${PORT:-5000}"

--- a/summarizer_server/nginx.conf
+++ b/summarizer_server/nginx.conf
@@ -1,3 +1,6 @@
+# 10 megs of storage = 160000 IP's
+limit_req_zone $binary_remote_addr zone=limiter:10m rate=30r/m;
+
 upstream flask {
     server api:5000;
 }
@@ -8,6 +11,9 @@ server {
     ssl_certificate     /etc/nginx/ssl/nginx.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx.key;
     location / {
+        # First 10 requests in the burst of 20 will be processed without delay.
+        # Subsequent requests are delayed to match the rate limit.
+        limit_req zone=limiter burst=20 delay=10;
         include uwsgi_params;
         uwsgi_pass flask;
     }


### PR DESCRIPTION
Before we start implementing rate limiting in python I figured we could make use of nginx's rate limiting and see how that goes. We can go down the python path later if we need to.

Essentially what this does is rate limiting by IP address. Right now it's set so that:
* 30 requests / min = 1 per 2 sec (per IP)
* burst of 20 means that the limit can be violated by up to 20 requests
* delay of 10 means the first 10 in the burst will be sent directly to flask, and the remaining 10 will be slightly delayed before being sent to flask