### PR TITLE
Nginx conf

### DIFF
--- a/summarizer_server/nginx.conf
+++ b/summarizer_server/nginx.conf
@@ -16,6 +16,9 @@ server {
         limit_req zone=limiter burst=20 delay=10;
         include uwsgi_params;
         uwsgi_pass flask;
+        # Prevents "pwrite() /var/cache/nginx/client_temp failed" logs in prod,
+        # by using main memory instead of a temp file:
+        # https://serverfault.com/questions/511789/nginx-client-request-body-is-buffered-to-a-temporary-file
         client_body_buffer_size     10M;
         client_max_body_size        10M;
     }

--- a/summarizer_server/nginx.conf
+++ b/summarizer_server/nginx.conf
@@ -16,5 +16,7 @@ server {
         limit_req zone=limiter burst=20 delay=10;
         include uwsgi_params;
         uwsgi_pass flask;
+        client_body_buffer_size     10M;
+        client_max_body_size        10M;
     }
 }


### PR DESCRIPTION
**The problem:**
Requests from the extension were returning internal server errors which we don't handled nicely on the front end yet. The NGINX container's logs showed multiple `pwrite() /var/cache/nginx/client_temp failed` logs and the summarizer_server logs weren't being added to iirc. This made me think it was an NGINX issue (but there may be something more to it).

**The "fix":**
Uses main memory instead of a temp file for NGINX to handle large requests (https://serverfault.com/questions/511789/nginx-client-request-body-is-buffered-to-a-temporary-file).

**Looking ahead:**
Makes me think that a user might've tried the extension on a site that they should not have, like an entire ebook or something. In the near future, a global blacklist/whitelist would be useful as would more logging :).