### PR TITLE
Mount log directory and log uwsgi to file

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -23,7 +23,7 @@ services:
       "--master",
       "--callable", "app",
       "--processes", "2",
-      "--logto", "/var/log/uwsgi.log",
+      "--logto", "/var/log/api.log",
     ]
   nginx:
     image: nginx:1.17

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,8 @@ services:
       - DEBUG
       - PORT
       - JOBLIB_MULTIPROCESSING=0 # this removes a uwsgi warning
+    volumes:
+      - "/var/log/docker:/var/log/"
     command: [
       "uwsgi",
       "--thunder-lock",
@@ -21,9 +23,11 @@ services:
       "--master",
       "--callable", "app",
       "--processes", "2",
+      "--logto", "/var/log/uwsgi.log",
     ]
   nginx:
     image: nginx:1.17
+    container_name: summarizer_nginx
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
This will let us start persisting logs even if the python container dies.

I didn't do the same thing for nginx logs since that gets a lot more spam from web scrapers and stuff.

The logs will be persisted to the vm at `/var/log/docker/*.log`