### PR TITLE
Remove Docs Folder

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,0 @@
-# Jent.ly Summarizer


### PR DESCRIPTION
Removing a docs folder that was created to test GitHub pages.

The official GitHub pages is deployed at jent-ly.github.io.