### PR TITLE
Set up nginx metrics and logs

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -18,9 +18,10 @@ gcloud beta compute --project "alpine-gasket-242504" ssh --zone "us-central1-a" 
 gcloud docker -- tag $IMAGE_REPO:$DEPLOY_SHA $IMAGE_REPO:latest && \
 docker-compose -f docker-compose.prod.yml down"
 
-echo "Step 2: copy docker-compose"
+echo "Step 2: copy files"
 
 gcloud compute scp docker-compose.prod.yml jently-docker-instance-2:~
+gcloud compute scp summarizer_server/nginx.conf summarizer_server/nginx_default.conf jently-docker-instance-2:~/summarizer_server/
 
 echo "Step 3: bring up server"
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -18,8 +18,6 @@ services:
       - ENV
       - DD_API_KEY
       - HOST
-    volumes:
-      - "/var/log/docker:/var/log/"
     links:
       - postgres
     depends_on:
@@ -34,8 +32,9 @@ services:
       "--master",
       "--callable", "app",
       "--processes", "2",
-      "--logto", "/var/log/api.log",
     ]
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "flask", "service": "backend"}]'
   nginx:
     image: nginx:1.17
     container_name: summarizer_nginx
@@ -43,7 +42,8 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - "./summarizer_server/nginx.conf:/etc/nginx/conf.d/default.conf:ro"
+      - "./summarizer_server/nginx.conf:/etc/nginx/nginx.conf:ro"
+      - "./summarizer_server/nginx_default.conf:/etc/nginx/conf.d/default.conf:ro"
       - "./summarizer_server/nginx.key:/etc/nginx/ssl/nginx.key:ro"
       - "./summarizer_server/nginx.crt:/etc/nginx/ssl/nginx.crt:ro"
     network_mode: "bridge"
@@ -51,6 +51,8 @@ services:
       - api
     depends_on:
       - api
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "nginx", "service": "backend"}]'
   postgres:
     image: postgres:12.0
     container_name: postgres
@@ -64,6 +66,8 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD
       - POSTGRES_DB=postgres
+    labels:
+      com.datadoghq.ad.logs: '[{"source": "postgres", "service": "backend"}]'
 
 volumes:
   postgres_data:

--- a/summarizer_server/nginx.conf
+++ b/summarizer_server/nginx.conf
@@ -1,25 +1,34 @@
-# 10 megs of storage = 160000 IP's
-limit_req_zone $binary_remote_addr zone=limiter:10m rate=30r/m;
+# This is the basic nginx log used by the nginx docker container.
+# Any modifications we make will be prefixed with MOD:
+user  nginx;
+worker_processes  1;
 
-upstream flask {
-    server api:5000;
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
 }
 
-server {
-    listen 80;
-    listen 443 ssl;
-    ssl_certificate     /etc/nginx/ssl/nginx.crt;
-    ssl_certificate_key /etc/nginx/ssl/nginx.key;
-    location / {
-        # First 10 requests in the burst of 20 will be processed without delay.
-        # Subsequent requests are delayed to match the rate limit.
-        limit_req zone=limiter burst=20 delay=10;
-        include uwsgi_params;
-        uwsgi_pass flask;
-        # Prevents "pwrite() /var/cache/nginx/client_temp failed" logs in prod,
-        # by using main memory instead of a temp file:
-        # https://serverfault.com/questions/511789/nginx-client-request-body-is-buffered-to-a-temporary-file
-        client_body_buffer_size     10M;
-        client_max_body_size        10M;
-    }
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    # MOD: add request_time to log format
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent $request_time "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
 }

--- a/summarizer_server/nginx_default.conf
+++ b/summarizer_server/nginx_default.conf
@@ -1,0 +1,34 @@
+# 10 megs of storage = 160000 IP's
+limit_req_zone $binary_remote_addr zone=limiter:10m rate=30r/m;
+
+upstream flask {
+    server api:5000;
+}
+
+server {
+    listen 80;
+    listen 443 ssl;
+    ssl_certificate     /etc/nginx/ssl/nginx.crt;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+    location / {
+        # First 10 requests in the burst of 20 will be processed without delay.
+        # Subsequent requests are delayed to match the rate limit.
+        limit_req zone=limiter burst=20 delay=10;
+        include uwsgi_params;
+        uwsgi_pass flask;
+        # Prevents "pwrite() /var/cache/nginx/client_temp failed" logs in prod,
+        # by using main memory instead of a temp file:
+        # https://serverfault.com/questions/511789/nginx-client-request-body-is-buffered-to-a-temporary-file
+        client_body_buffer_size     10M;
+        client_max_body_size        10M;
+    }
+
+    location /nginx_status {
+        stub_status;
+
+        access_log off;
+        # docker networking: https://stackoverflow.com/questions/26090231/nginx-status-page-in-docker
+        allow 172.17.0.0/16;
+        deny all;
+    }
+}


### PR DESCRIPTION
In addition to these changes I had to follow https://www.datadoghq.com/blog/how-to-monitor-nginx-with-datadog/ which is essentially:
* install datadog agent on the host vm (outside of docker)
* configure it to read the `localhost/nginx_status` page
* configure it to retrieve the `docker logs` from all our containers (now flask logs go to dd too)

Now in `server.py` we might be able to report to the agent directly rather than through http.