### PR TITLE
Use certbot container to retrieve and set up certs

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,7 @@ version: "3.4"
 
 services:
   api:
-    image: gcr.io/alpine-gasket-242504/summarizer-server:latest
+    image: docker.pkg.github.com/jent-ly/summarizer_server/server:latest
     container_name: summarizer_server
     ports:
       - "${PORT:-5000}:${PORT:-5000}"
@@ -42,10 +42,11 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - "./summarizer_server/nginx.conf:/etc/nginx/nginx.conf:ro"
-      - "./summarizer_server/nginx_default.conf:/etc/nginx/conf.d/default.conf:ro"
-      - "./summarizer_server/nginx.key:/etc/nginx/ssl/nginx.key:ro"
-      - "./summarizer_server/nginx.crt:/etc/nginx/ssl/nginx.crt:ro"
+      - "./data/nginx.conf:/etc/nginx/nginx.conf:ro"
+      - "./data/nginx_default.conf:/etc/nginx/conf.d/default.conf:ro"
+      # certbot setup
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
     network_mode: "bridge"
     links:
       - api
@@ -68,6 +69,11 @@ services:
       - POSTGRES_DB=postgres
     labels:
       com.datadoghq.ad.logs: '[{"source": "postgres", "service": "backend"}]'
+  certbot:
+    image: certbot/certbot
+    volumes:
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
 
 volumes:
   postgres_data:

--- a/init-letsencrypt.sh
+++ b/init-letsencrypt.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+# From https://medium.com/@pentacent/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71
+
+if ! [ -x "$(command -v docker-compose)" ]; then
+  echo 'Error: docker-compose is not installed.' >&2
+  exit 1
+fi
+
+domains=(api.jent.ly)
+rsa_key_size=4096
+data_path="./data/certbot"
+email="jently.summarizer@gmail.com" # Adding a valid address is strongly recommended
+staging=0 # Set to 1 if you're testing your setup to avoid hitting request limits
+
+if [ -d "$data_path" ]; then
+  read -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
+    exit
+  fi
+fi
+
+
+if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
+  echo "### Downloading recommended TLS parameters ..."
+  mkdir -p "$data_path/conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
+  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  echo
+fi
+
+echo "### Creating dummy certificate for $domains ..."
+path="/etc/letsencrypt/live/$domains"
+mkdir -p "$data_path/conf/live/$domains"
+docker-compose run --rm --entrypoint "\
+  openssl req -x509 -nodes -newkey rsa:1024 -days 1\
+    -keyout '$path/privkey.pem' \
+    -out '$path/fullchain.pem' \
+    -subj '/CN=localhost'" certbot
+echo
+
+
+echo "### Starting nginx ..."
+docker-compose up --force-recreate -d nginx
+echo
+
+echo "### Deleting dummy certificate for $domains ..."
+docker-compose run --rm --entrypoint "\
+  rm -Rf /etc/letsencrypt/live/$domains && \
+  rm -Rf /etc/letsencrypt/archive/$domains && \
+  rm -Rf /etc/letsencrypt/renewal/$domains.conf" certbot
+echo
+
+
+echo "### Requesting Let's Encrypt certificate for $domains ..."
+#Join $domains to -d args
+domain_args=""
+for domain in "${domains[@]}"; do
+  domain_args="$domain_args -d $domain"
+done
+
+# Select appropriate email arg
+case "$email" in
+  "") email_arg="--register-unsafely-without-email" ;;
+  *) email_arg="--email $email" ;;
+esac
+
+# Enable staging mode if needed
+if [ $staging != "0" ]; then staging_arg="--staging"; fi
+
+docker-compose run --rm --entrypoint "\
+  certbot certonly --webroot -w /var/www/certbot \
+    $staging_arg \
+    $email_arg \
+    $domain_args \
+    --rsa-key-size $rsa_key_size \
+    --agree-tos \
+    --force-renewal" certbot
+echo
+
+echo "### Reloading nginx ..."
+docker-compose exec nginx nginx -s reload

--- a/summarizer_server/nginx_default.conf
+++ b/summarizer_server/nginx_default.conf
@@ -8,8 +8,11 @@ upstream flask {
 server {
     listen 80;
     listen 443 ssl;
-    ssl_certificate     /etc/nginx/ssl/nginx.crt;
-    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+    ssl_certificate /etc/letsencrypt/live/api.jent.ly/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.jent.ly/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
     location / {
         # First 10 requests in the burst of 20 will be processed without delay.
         # Subsequent requests are delayed to match the rate limit.
@@ -30,5 +33,10 @@ server {
         # docker networking: https://stackoverflow.com/questions/26090231/nginx-status-page-in-docker
         allow 172.17.0.0/16;
         deny all;
+    }
+
+    # for cert verification
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
     }
 }


### PR DESCRIPTION
This should make it so that we don't have to manage our own certs. The container should be able to handle everything.

Pretty much followed https://medium.com/@pentacent/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71 for this.